### PR TITLE
Update CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 When making changes, do so on your own branch and submit the changes as a pull request. Do not force-push to the `main` branch.<br>
-When creating a pull request, use a branch name starting with your username (`<username>-<topic>`). Do not merge your own pull request yourself (unless it's a fix caught by the checkers). Let another collaborator review and merge.<br>
-Exception: if your pull request has two approving reviews then you may merge it.<br>
+Small updates should have a branch name starting with your username (`<username>-<topic>`). Larger branches which multiple people may push to need not have the username prefix.<br>
 If somebody is assigned to a pull request, do not merge it unless they have submitted an approving review.<br>
-Other than that, be free with the merge button on pull requests that are not yours.<br>
 Use "Squash and Merge" when merging a pull request, as opposed to a regular merge. After merging a pull request, delete the HEAD branch.<br>
 If a pull request changes files that somebody else added, request a review from them. GitHub should automatically give you advice on who to request.<br>


### PR DESCRIPTION
The request not to merge pull requests without approving reviews is outdated with new branch protection rules.
In addition, I updated the branch naming strategy.